### PR TITLE
`datasets` 周辺の import を変更

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -8,3 +8,6 @@ ignore_missing_imports = True
 
 [mypy-trl.*]
 ignore_missing_imports = True
+
+[mypy-datasets.*]
+ignore_missing_imports = True

--- a/src/dataset/load.py
+++ b/src/dataset/load.py
@@ -1,8 +1,7 @@
 import glob
 
 import yaml
-
-from datasets import load_dataset
+from datasets.load import load_dataset
 
 
 # 指定されたファイルパスからyamlファイルを読み込む

--- a/src/train.py
+++ b/src/train.py
@@ -3,6 +3,8 @@ import sys
 
 import wandb
 import yaml
+from datasets.arrow_dataset import Dataset
+from datasets.load import load_dataset
 from peft import LoraConfig
 from transformers import (
     AutoModelForCausalLM,
@@ -11,8 +13,6 @@ from transformers import (
     TrainingArguments,
 )
 from trl import SFTTrainer
-
-from datasets import Dataset, load_dataset
 
 os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "true"
 


### PR DESCRIPTION
Fix imports from `datasets`

Use 

```
from datasets.arrow_dataset import Dataset
```

and

```
from datasets.load import load_dataset
```
