### PR TITLE
ignore `.mypy_cache` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 output
 wandb
 /.venv
+/.mypy_cache


### PR DESCRIPTION
`mypy` で型検査したときにできるキャッシュディレクトリをバージョン管理から外します。
